### PR TITLE
Fixed CRGB bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@
 
 util/imageconverter/og
 util/imageconverter/venv
+
+.pioenvs
+.piolibdeps
+.clang_complete
+.gcc-flags.json
+.pio

--- a/include/colorconversion.h
+++ b/include/colorconversion.h
@@ -43,7 +43,7 @@ inline constexpr uint16_t fromRGB( uint8_t r, uint8_t g, uint8_t b) {
   return ( ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3) );
 }
 
-inline uint16_t convertCRGBto565(CRGB& in) {
+inline uint16_t convertCRGBto565(CRGB in) {
   return fromRGB(in.r, in.g, in.b);
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,8 +19,8 @@ board_build.filesystem = littlefs
 extra_scripts = replace_fs.py
 upload_speed = 921600
 monitor_speed = 115200
-upload_port = /dev/ttyUSB0
-monitor_port = /dev/ttyUSB0
+upload_port = COM3
+monitor_port = COM3
 lib_deps = 
 	ESP Async WebServer
 	adafruit/Adafruit GFX Library@^1.10.1

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,8 +19,6 @@ board_build.filesystem = littlefs
 extra_scripts = replace_fs.py
 upload_speed = 921600
 monitor_speed = 115200
-upload_port = COM3
-monitor_port = COM3
 lib_deps = 
 	ESP Async WebServer
 	adafruit/Adafruit GFX Library@^1.10.1
@@ -39,6 +37,7 @@ build_flags =
 	-I lib
 	-D USE_MAX7219
 	-std=gnu++17
+	-DFASTLED_ALL_PINS_HARDWARE_SPI
 	-O3
 ; src_filter = +<*> -<.git/> -<.svn/> -<example/> -<examples/> -<test/> -<tests/>
 ; 	-<scene/>

--- a/src/displays/fastled/fastleddisplay.h
+++ b/src/displays/fastled/fastleddisplay.h
@@ -40,12 +40,12 @@ public:
 
     void show() {
         // FastLED.setBrightness(16);
-        unsigned long before = micros();
+        // unsigned long before = micros();
         for (auto &matrixString: _strings) {
             matrixString->show();
         }
         // FastLED.show();
-        unsigned long after = micros();
+        // unsigned long after = micros();
         // Serial.print("FASTLED TOOK: ");
         // Serial.print(after - before);
         // Serial.println(" us");

--- a/src/displays/fastled/fastledstring.h
+++ b/src/displays/fastled/fastledstring.h
@@ -107,7 +107,7 @@ public:
             }
             controller->setLeds(pixels.get(), num_pixels);
         }
-        swapped != swapped;
+        swapped = !swapped;
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,6 @@
 #include <stdint.h>
 
 // #define FASTLED_ESP32_I2S
-
 #include <FastLED.h>
 // #include "AsyncJson.h"
 // #include "ArduinoJson.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -170,7 +170,7 @@ void updateLoop(void *params)
     // For benchmarking
     unsigned long before;
     unsigned long after;
-    unsigned long delta;
+    __attribute__((unused)) unsigned long delta;
 
     while (true)
     {
@@ -208,8 +208,8 @@ void updateLoop(void *params)
 
 void drawLoop(void *params)
 {
-    unsigned long begin = 0;
-    unsigned long end = 0;
+    __attribute__((unused)) unsigned long begin = 0;
+    __attribute__((unused)) unsigned long end = 0;
     while (true)
     {
         begin = micros();

--- a/src/scene/visitors/elementrgbbitmapsetter.cpp
+++ b/src/scene/visitors/elementrgbbitmapsetter.cpp
@@ -9,6 +9,11 @@
 #include "bitmaps.h"
 
 
+inline uint16_t crgbToRGB565(CRGB color) {
+  return ((color.r & 0xF8) << 8) | ((color.g & 0xFC) << 3) | ((color.b & 0xF8) >> 3);
+}
+
+
 void ElementRGBBitmapSetter::follow_children(Element* el) {
     for (Element* child: el->getChildren()) {
         child->accept(this);
@@ -26,7 +31,7 @@ void ElementRGBBitmapSetter::visit(AdafruitGFXElement* el) {
 
         for (uint16_t x = 0; x < el->width(); x++) {
             for (uint16_t y = 0; y < el->height(); y++) {
-                el->drawPixel(x, y, cur_bitmap->getPixel(x, y));
+                el->drawPixel(x, y, crgbToRGB565(cur_bitmap->getPixel(x, y)));
             }
         }
     }

--- a/src/scene/visitors/elementrgbbitmapsetter.cpp
+++ b/src/scene/visitors/elementrgbbitmapsetter.cpp
@@ -8,10 +8,7 @@
 #include "scene/scene.h"
 #include "bitmaps.h"
 
-
-inline uint16_t crgbToRGB565(CRGB color) {
-  return ((color.r & 0xF8) << 8) | ((color.g & 0xFC) << 3) | ((color.b & 0xF8) >> 3);
-}
+#include "colorconversion.h"
 
 
 void ElementRGBBitmapSetter::follow_children(Element* el) {

--- a/src/scene/visitors/elementrgbbitmapsetter.cpp
+++ b/src/scene/visitors/elementrgbbitmapsetter.cpp
@@ -28,7 +28,7 @@ void ElementRGBBitmapSetter::visit(AdafruitGFXElement* el) {
 
         for (uint16_t x = 0; x < el->width(); x++) {
             for (uint16_t y = 0; y < el->height(); y++) {
-                el->drawPixel(x, y, crgbToRGB565(cur_bitmap->getPixel(x, y)));
+                el->drawPixel(x, y, convertCRGBto565(cur_bitmap->getPixel(x, y)));
             }
         }
     }


### PR DESCRIPTION
This fixes a few problems:

First, it resolves a bug related to trying to pass a `CRGB` object into a function that expects a color in `RGB565` format. I wrote a simple bit manipulation that puts all the relevant bits into their proper `uint16_t` places, resolving this bug.

Second, it resolves a few compiler warnings about unused variables, by marking them as unused.

Third, it adds proper Platform.IO information to the `.gitignore`.

Fourth, uhhh idk I didn't really mean to change the `platformio.ini` configuration, but it now uses a Windows serial port object, which is interesting.